### PR TITLE
Limit the amount of history pulled back

### DIFF
--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -2,7 +2,7 @@ import datetime
 import abc
 import re
 from typing import NamedTuple
-from .history_const import B_G_HISTORY_FORMAT, AMAX_HISTORY_FORMAT, SOLUTION_HISTORY_FORMAT
+from .history_const import B_G_HISTORY_FORMAT, AMAX_HISTORY_FORMAT, SOLUTION_HISTORY_FORMAT, NO_EVENTS
 from .utils import BE_INT, LE_INT
 
 class HistoryEvent(NamedTuple):
@@ -22,7 +22,7 @@ class History:
     @property
     def last_event_id(self):
         if not self._events:
-            return 0
+            return NO_EVENTS
         return self._events[-1][0]
 
     def init_raw_history(self, panel_type):

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -45,9 +45,9 @@ class History:
             start = max(0, start)
             self._events.append((start, SENTINEL_EVENT))
             return True
+        elif self._events[0][1] == SENTINEL_EVENT:
+            self._events = []
         if count:
-            if self._events[0][0] == SENTINEL_EVENT:
-                self._events = []
             try:
                 events = self._parser.parse_events(start, event_data, count)
                 for (id, text) in events:

--- a/bosch_alarm_mode2/history_const.py
+++ b/bosch_alarm_mode2/history_const.py
@@ -1,5 +1,5 @@
-
-
+NO_EVENTS = 0xFFFFFFFF
+EVENT_LOOKBACK_COUNT = 30
 
 B_G_HISTORY_FORMAT = {
     "0": "End of Log Marker1",

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -236,15 +236,14 @@ class Panel:
         return start, count
 
     async def _load_history(self):
-        if self._history.last_event_id == NO_EVENTS:
-            start, count = await self._read_history(self._history.last_event_id)
-            start -= EVENT_LOOKBACK_COUNT
-            start = max(0, start)
-            start, count = await self._read_history(start)
-            if count == 0:
-                return
+        load_old_events = self._history.last_event_id == NO_EVENTS
         while True:
             start, count = await self._read_history(self._history.last_event_id)
+            if load_old_events:
+                start -= EVENT_LOOKBACK_COUNT
+                start = max(0, start)
+                start, count = await self._read_history(start)
+                load_old_events = False
             if count == 0:
                 break
 

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from .const import *
 from .connection import Connection
 from .history import History, HistoryEvent
-from .history_const import NO_EVENTS, EVENT_LOOKBACK_COUNT
 from .utils import BE_INT, Observable
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Instead of pulling the entire panels history back, only load the last 30 events.
Also, update the `_last_msg` when retrieving history, to make sure that loading lots of events at once won't ever cause issues.