### PR TITLE
Implement raw version of subscription history

### DIFF
--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -50,6 +50,11 @@ class History:
             self._parser = AmaxHistory()
         else:
             self._parser = BGHistory()
+    
+    def _append_error(self, id, excp):
+        error_str = f"parse error: {repr(excp)}"
+        LOG.error("History event " + error_str)
+        self._events.append(HistoryEvent(id, datetime.now(), error_str))
 
     def parse_polled_events(self, event_data):
         count = event_data[0]
@@ -67,9 +72,7 @@ class History:
                 LOG.debug(e)
             self._events.extend(events)
         except Exception as excp:
-            error_str = f"parse error: {repr(excp)}"
-            LOG.error("History event " + error_str)
-            self._events.append(HistoryEvent(start + count, datetime.now(), error_str))
+            self._append_error(start + count, excp)
         return self.last_event_id
 
     def parse_subscription_event(self, raw_event):
@@ -82,9 +85,7 @@ class History:
             self._events.append(e)
             return total_len
         except Exception as excp:
-            error_str = f"parse error: {repr(excp)}"
-            LOG.error("History event " + error_str)
-            self._events.append(HistoryEvent(event_id + 1, datetime.now(), error_str))
+            self._append_error(event_id + 1, excp)
             return len(raw_event)
 class HistoryParser:
     __metaclass__ = abc.ABCMeta

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -21,7 +21,7 @@ class HistoryEvent(NamedTuple):
 
 class HistoryEventParams(NamedTuple):
     date: datetime
-    event_code: int
+    event_code: str
     area: int
     param1: int
     param2: int
@@ -73,19 +73,19 @@ class History:
         return self.last_event_id
 
     def parse_subscription_event(self, raw_event):
-        text_len = BE_INT.int16(raw_event, 23)
-        event_id = BE_INT.int32(raw_event)
-        total_len = 25 + text_len
         try:
+            text_len = BE_INT.int16(raw_event, 23)
+            event_id = BE_INT.int32(raw_event)
+            total_len = 25 + text_len
             e = self._parser.parse_subscription_event(raw_event)
             LOG.debug(e)
             self._events.append(e)
+            return total_len
         except Exception as excp:
             error_str = f"parse error: {repr(excp)}"
             LOG.error("History event " + error_str)
             self._events.append(HistoryEvent(event_id + 1, datetime.now(), error_str))
-        return total_len
-
+            return len(raw_event)
 class HistoryParser:
     __metaclass__ = abc.ABCMeta
 

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -83,7 +83,7 @@ class History:
         except Exception as excp:
             error_str = f"parse error: {repr(excp)}"
             LOG.error("History event " + error_str)
-            self._events.append(HistoryEvent(event_id, datetime.now(), error_str))
+            self._events.append(HistoryEvent(event_id + 1, datetime.now(), error_str))
         return total_len
 
 class HistoryParser:
@@ -115,7 +115,7 @@ class TextHistory(HistoryParser):
         # Not sure why, but there is an extra 0 in subscription text
         date, time, _, message = re.split(r"\s+", line, 3)
         date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
-        return HistoryEvent(BE_INT.int32(raw_event), date, message)
+        return HistoryEvent(BE_INT.int32(raw_event) + 1, date, message)
 
 class RawHistory(HistoryParser):
     def parse_events(self, start, event_data, count) -> [HistoryEvent]:
@@ -139,7 +139,7 @@ class RawHistory(HistoryParser):
         date, time, _ = re.split(r"\s+", line, 2)
         date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
         params = HistoryEventParams(date=date, event_code=event_code, area=area, param1=param1, param2=param2, param3=param3)
-        return HistoryEvent(BE_INT.int32(raw_event), *self._parse_event(params))
+        return HistoryEvent(BE_INT.int32(raw_event) + 1, *self._parse_event(params))
 
     @abc.abstractmethod
     def _parse_event_params(self, event) -> HistoryEventParams:

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -19,6 +19,14 @@ class HistoryEvent(NamedTuple):
     def __repr__(self):
         return f"[{self.id}] {self.date} | {self.message}"
 
+class HistoryEventParams(NamedTuple):
+    date: datetime
+    event_code: int
+    area: int
+    param1: int
+    param2: int
+    param3: int
+
 class History:
     def __init__(self, events) -> None:
         self._events = events
@@ -66,12 +74,16 @@ class History:
 
     def parse_subscription_event(self, raw_event):
         text_len = BE_INT.int16(raw_event, 23)
+        event_id = BE_INT.int16(raw_event, 4)
         total_len = 25 + text_len
-        line = raw_event[25:total_len - 1].decode()
-        # Not sure why, but there is an extra 0 in subscription text
-        date, time, _, message = re.split(r"\s+", line, 3)
-        date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
-        self._events.append((BE_INT.int16(raw_event, 4), date, message))
+        try:
+            e = self._parser.parse_subscription_event(raw_event)
+            LOG.debug(e)
+            self._events.append(e)
+        except Exception as excp:
+            error_str = f"parse error: {repr(excp)}"
+            LOG.error("History event " + error_str)
+            self._events.append(HistoryEvent(event_id, datetime.now(), error_str))
         return total_len
 
 class HistoryParser:
@@ -79,6 +91,9 @@ class HistoryParser:
 
     @abc.abstractmethod
     def parse_events(self, start, event_data, count) -> [HistoryEvent]:
+        pass
+    @abc.abstractmethod
+    def parse_subscription_event(self, event_data) -> HistoryEvent:
         pass
 
 class TextHistory(HistoryParser):
@@ -91,17 +106,46 @@ class TextHistory(HistoryParser):
             events.append(HistoryEvent(start + i, date, message))
             event_data = event_data[len(line)+1:]
         return events
+    
+    @abc.abstractmethod
+    def parse_subscription_event(self, raw_event) -> HistoryEvent:
+        text_len = BE_INT.int16(raw_event, 23)
+        total_len = 25 + text_len
+        line = raw_event[25:total_len - 1].decode()
+        # Not sure why, but there is an extra 0 in subscription text
+        date, time, _, message = re.split(r"\s+", line, 3)
+        date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
+        return HistoryEvent(BE_INT.int16(raw_event, 4), date, message)
 
 class RawHistory(HistoryParser):
     def parse_events(self, start, event_data, count) -> [HistoryEvent]:
         events = []
         event_length = len(event_data) // count
         for i in range(count):
-            events.append(HistoryEvent(start + i, *self._parse_event(event_data)))
+            events.append(HistoryEvent(start + i, *self._parse_event(self._parse_event_params(event_data))))
             event_data = event_data[event_length:]
         return events
+
     @abc.abstractmethod
-    def _parse_event(self, event) -> (datetime, str):
+    def parse_subscription_event(self, raw_event) -> HistoryEvent:
+        event_code = str(BE_INT.int16(raw_event, 4))
+        area = BE_INT.int16(raw_event, 6)
+        param1 = BE_INT.int16(raw_event, 8)
+        param2 = BE_INT.int16(raw_event, 10)
+        param3 = BE_INT.int16(raw_event, 12)
+        text_len = BE_INT.int16(raw_event, 23)
+        total_len = 25 + text_len
+        line = raw_event[25:total_len - 1].decode()
+        date, time, _ = re.split(r"\s+", line, 2)
+        date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
+        params = HistoryEventParams(date=date, event_code=event_code, area=area, param1=param1, param2=param2, param3=param3)
+        return HistoryEvent(BE_INT.int16(raw_event, 4), *self._parse_event(params))
+
+    @abc.abstractmethod
+    def _parse_event_params(self, event) -> HistoryEventParams:
+        pass
+    @abc.abstractmethod
+    def _parse_event(self, date, event_code, param1, param2, param3) -> (datetime, str):
         pass
 
 def _parse_sol_amax_params(event):
@@ -118,22 +162,26 @@ def _parse_sol_amax_params(event):
     event_code = str(event[6])
     param1 = LE_INT.int16(event, 4)
     param2 = event[7]
-    return (event_code, date, param1, param2)
+    return HistoryEventParams(date=date, event_code=event_code, area=param1, param1=param1, param2=param2, param3=0)
 
 class SolutionHistory(RawHistory):
-    def _parse_event(self, event):
-        (event_code, date, param1, param2) = _parse_sol_amax_params(event)
-        user = SOLUTION_USERS.get(param2, f"User {param2}" if param2 <= 32 else "")
-        return (date, SOLUTION_HISTORY_FORMAT[event_code].format(
-            user=user, param1=param1, param2=param2))
+    def _parse_event_params(self, event) -> HistoryEventParams:
+        return _parse_sol_amax_params(event) 
+    
+    def _parse_event(self, event: HistoryEventParams):
+        user = SOLUTION_USERS.get(event.param2, f"User {event.param2}" if event.param2 <= 32 else "")
+        return (event.date, SOLUTION_HISTORY_FORMAT[event.event_code].format(
+            user=user, param1=event.param1, param2=event.param2))
 
 class AmaxHistory(RawHistory):
-    def _parse_event(self, event):
-        (event_code, date, param1, param2) = _parse_sol_amax_params(event)
+    def _parse_event_params(self, event) -> HistoryEventParams:
+        return _parse_sol_amax_params(event)
+    
+    def _parse_event(self, event: HistoryEventParams):
         # Amax requires different strings depending on param1 sometimes
         key_specs = [
             ("", None),
-            ("_%d" % param1, None),
+            ("_%d" % event.param1, None),
             ("_zone", None),
             ("_keypad", lambda p: p <= 16),
             ("_dx2", lambda p: p <= 108),
@@ -141,14 +189,14 @@ class AmaxHistory(RawHistory):
             ("_b4", lambda p: p in (150, 151)),
         ]
         for (suffix, predicate) in key_specs:
-            if predicate and not predicate(param1):
+            if predicate and not predicate(event.param1):
                 continue
-            if template := AMAX_HISTORY_FORMAT.get(event_code + suffix):
-                return (date, template.format(param1=param1, param2=param2))
-        return (date, f"Unknown event id={event_code} p1={param1} p2={param2}")
+            if template := AMAX_HISTORY_FORMAT.get(event.event_code + suffix):
+                return (event.date, template.format(param1=event.param1, param2=event.param2))
+        return (event.date, f"Unknown event id={event.event_code} p1={event.param1} p2={event.param2}")
 
 class BGHistory(RawHistory):
-    def _parse_event(self, event):
+    def _parse_event_params(self, event) -> HistoryEventParams:
         timestamp = BE_INT.int32(event, 10)
         year = 2010 + (timestamp >> 26)
         month = (timestamp >> 22) & 0x0F
@@ -163,5 +211,7 @@ class BGHistory(RawHistory):
         param1 = BE_INT.int16(event, 4)
         param2 = BE_INT.int16(event, 6)
         param3 = BE_INT.int16(event, 8)
-        return (date, B_G_HISTORY_FORMAT[event_code].format(
-            area=area, param1=param1, param2=param2, param3=param3))
+        return HistoryEventParams(date=date, event_code=event_code, area=area, param1=param1, param2=param2, param3=param3)
+    def _parse_event(self, event: HistoryEventParams):
+        return (event.date, B_G_HISTORY_FORMAT[event.event_code].format(
+            area=event.area, param1=event.param1, param2=event.param2, param3=event.param3))

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -126,7 +126,6 @@ class RawHistory(HistoryParser):
             event_data = event_data[event_length:]
         return events
 
-    @abc.abstractmethod
     def parse_subscription_event(self, raw_event) -> HistoryEvent:
         event_code = str(BE_INT.int16(raw_event, 4))
         area = BE_INT.int16(raw_event, 6)

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -74,7 +74,7 @@ class History:
 
     def parse_subscription_event(self, raw_event):
         text_len = BE_INT.int16(raw_event, 23)
-        event_id = BE_INT.int16(raw_event, 4)
+        event_id = BE_INT.int32(raw_event)
         total_len = 25 + text_len
         try:
             e = self._parser.parse_subscription_event(raw_event)
@@ -115,7 +115,7 @@ class TextHistory(HistoryParser):
         # Not sure why, but there is an extra 0 in subscription text
         date, time, _, message = re.split(r"\s+", line, 3)
         date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
-        return HistoryEvent(BE_INT.int16(raw_event, 4), date, message)
+        return HistoryEvent(BE_INT.int32(raw_event), date, message)
 
 class RawHistory(HistoryParser):
     def parse_events(self, start, event_data, count) -> [HistoryEvent]:
@@ -139,7 +139,7 @@ class RawHistory(HistoryParser):
         date, time, _ = re.split(r"\s+", line, 2)
         date = datetime.strptime(f"{date} {time}", "%m/%d/%Y %I:%M%p")
         params = HistoryEventParams(date=date, event_code=event_code, area=area, param1=param1, param2=param2, param3=param3)
-        return HistoryEvent(BE_INT.int16(raw_event, 4), *self._parse_event(params))
+        return HistoryEvent(BE_INT.int32(raw_event), *self._parse_event(params))
 
     @abc.abstractmethod
     def _parse_event_params(self, event) -> HistoryEventParams:


### PR DESCRIPTION
While thinking about #11, i realised that we would want a raw version of the subscription history events as well, so I have split the history parser up a little to allow reusing that logic for subscriptions as well.
This also means things won't crash if something goes wrong while parsing subscription history events.