### PR TITLE
Remove text history, fix up subscription history timestamp parsing

### DIFF
--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -73,7 +73,7 @@ class History:
         event_length = len(event_data) // count
         for i in range(start, start + count):
             try:
-                e = self._parser.parse_raw_event(i, event_data)
+                e = self._parser.parse_polled_event(i, event_data)
                 LOG.debug(e)
                 self._events.append(e)
                 event_data = event_data[event_length:]
@@ -115,7 +115,7 @@ class HistoryParser:
             date=date, event_code=event_code, area=area, param1=param1, param2=param2, param3=param3)
         return HistoryEvent(BE_INT.int32(raw_event) + 1, *self._parse_event(params))
 
-    def parse_raw_event(self, id, event_data):
+    def parse_polled_event(self, id, event_data):
         return HistoryEvent(id, *self._parse_event(self._parse_event_params(event_data)))
 
     @abc.abstractmethod

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -116,7 +116,7 @@ class HistoryParser:
         return HistoryEvent(BE_INT.int32(raw_event) + 1, *self._parse_event(params))
 
     def parse_raw_event(self, id, event_data):
-        return HistoryEvent(id, *self.parse_raw_event(self._parse_event_params(event_data)))
+        return HistoryEvent(id, *self._parse_event(self._parse_event_params(event_data)))
 
     @abc.abstractmethod
     def _parse_subscription_event_timestamp(self, timestamp) -> datetime:

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -121,7 +121,7 @@ class HistoryParser:
         pass
     @abc.abstractmethod
     def _parse_event(self, date, event_code, param1, param2, param3) -> (datetime, str):
-        pass    
+        pass
 
 def _parse_sol_amax_params(event):
     timestamp = LE_INT.int16(event)

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -31,8 +31,8 @@ class HistoryEventParams(NamedTuple):
 
 
 class History:
-    def __init__(self, events) -> None:
-        self._events = events
+    def __init__(self) -> None:
+        self._events = []
         self._parser = None
         self._max_count = 0
 

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -329,7 +329,7 @@ class Panel:
         self._supports_command_request_area_text_cf01 = (bitmask[7] & 0x20) != 0
         self._supports_command_request_area_text_cf03 = (bitmask[7] & 0x08) != 0
         supports_history_raw_ext = (bitmask[16] & 0x02) != 0
-        self._history.init_raw_history(data[0])
+        self._history.init_for_panel(data[0])
         self._history_cmd = (
                 CMD.REQUEST_RAW_HISTORY_EVENTS_EXT if supports_history_raw_ext else
                 CMD.REQUEST_RAW_HISTORY_EVENTS)

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -102,7 +102,7 @@ class Point(PanelEntity):
 class Panel:
     """ Connection to a Bosch Alarm Panel using the "Mode 2" API. """
 
-    def __init__(self, host, port, passcode, previous_history_events = []):
+    def __init__(self, host, port, passcode):
         LOG.debug("Panel created")
         self._host = host
         self._port = port
@@ -117,7 +117,7 @@ class Panel:
         self.model = None
         self.protocol_version = None
         self.serial_number = None
-        self._history = History(previous_history_events)
+        self._history = History()
         self._history_cmd = CMD.REQUEST_TEXT_HISTORY_EVENTS
         self.areas = {}
         self.points = {}

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -328,13 +328,11 @@ class Panel:
         self._supports_subscriptions = (bitmask[0] & 0x40) != 0
         self._supports_command_request_area_text_cf01 = (bitmask[7] & 0x20) != 0
         self._supports_command_request_area_text_cf03 = (bitmask[7] & 0x08) != 0
-        supports_history_text = (bitmask[5] & 0x80) != 0
         supports_history_raw_ext = (bitmask[16] & 0x02) != 0
-        if not supports_history_text:
-            self._history.init_raw_history(data[0])
-            self._history_cmd = (
-                    CMD.REQUEST_RAW_HISTORY_EVENTS_EXT if supports_history_raw_ext else
-                    CMD.REQUEST_RAW_HISTORY_EVENTS)
+        self._history.init_raw_history(data[0])
+        self._history_cmd = (
+                CMD.REQUEST_RAW_HISTORY_EVENTS_EXT if supports_history_raw_ext else
+                CMD.REQUEST_RAW_HISTORY_EVENTS)
         supports_serial_read = (bitmask[13] & 0x04) != 0
         if supports_serial_read:
             data = await self._connection.send_command(


### PR DESCRIPTION
The subscription events return a timestamp in an internal format it seems, which does change a bit between the different panels. 
Sadly, the solution panels don't even give you a date as part of the text format either, so we can't even rely on parsing that either.
I don't think amax panels even support subscriptions, nor do i expect there to ever be a dev firmware that adds that functionality, but it'll likely be the same format as solution either way if they do add one, so i've just made that assumption here