### PR TITLE
Add check for using an automation passcode on a solution / amax panel

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -228,7 +228,7 @@ class Panel:
 
     async def _load_history(self):
         # Don't retrieve history when armed, as panels do not support this.
-        if any(area.is_armed() for area in self.areas):
+        if any(area.is_armed() for area in self.areas.values()):
             return
         start_size = len(self.events)
         start_t = time.perf_counter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bosch-alarm-mode2"
-version = "0.3.22"
+version = "0.3.24"
 description = ""
 authors = ["Michael Grigoriev <mag@luminal.org>"]
 


### PR DESCRIPTION
Not quite sure what error message to use here - and we might even want  to roll this into the idea of using proper exceptions too. This however does work, on my solution panel this catches me trying to use an automation passcode instead of the RSC+ passcode.