### PR TITLE
Fallback to CF01 when CF03 fails

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -453,7 +453,11 @@ class Panel:
         enabled_ids = await self._load_entity_set(config_cmd)
         
         if self._supports_command_request_area_text_cf03:
-            return await self._load_names_cf03(name_cmd, enabled_ids)
+            try:
+                return await self._load_names_cf03(name_cmd, enabled_ids)
+            except:
+                # If the panel doesn't really support CF03, then use CF01
+                self._supports_command_request_area_text_cf03 = False
 
         if self._supports_command_request_area_text_cf01:
             return await self._load_names_cf01(name_cmd, enabled_ids, id_size)

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -456,8 +456,11 @@ class Panel:
             try:
                 return await self._load_names_cf03(name_cmd, enabled_ids)
             except:
-                # If the panel doesn't really support CF03, then use CF01
-                self._supports_command_request_area_text_cf03 = False
+                if self._connection.protocol == PROTOCOL.BASIC:
+                    raise
+                # downgrade protocol to basic and retry
+                self._connection.protocol = PROTOCOL.BASIC
+                return await self._load_names_cf03(name_cmd, enabled_ids)
 
         if self._supports_command_request_area_text_cf01:
             return await self._load_names_cf01(name_cmd, enabled_ids, id_size)


### PR DESCRIPTION
Not sure about this patch ...

I don't know why; I can't load names from my B4512 panel with CF03 even when support should be enabled.
`_load_names_cf03` receives a truncated response.  Reverting to CF01 did the trick for me.
