### PR TITLE
Ignore outputs with an empty name

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -399,7 +399,7 @@ class Panel:
 
     async def _load_outputs(self):
         names = await self._load_names(CMD.OUTPUT_TEXT, CMD.REQUEST_CONFIGURED_OUTPUTS, "OUTPUT", 1)
-        self.outputs = {id: Output(name) for id, name in names.items()}
+        self.outputs = {id: Output(name) for id, name in names.items() if name}
 
     async def _load_areas(self):
         names = await self._load_names(CMD.AREA_TEXT, CMD.REQUEST_CONFIGURED_AREAS, "AREA")


### PR DESCRIPTION
Hopefully we will find a better solution than this, but I can confirm that if i leave the name empty on my outputs, they just use the default OUTPUTx name.