### PR TITLE
Disable the extended protocol for now

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -374,8 +374,8 @@ class Panel:
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
         # Section 13.2 of the protocol spec.
         bitmask = data[23:].ljust(33, b'\0')
-        if bitmask[0] & 0x10:
-            self._connection.protocol = PROTOCOL.EXTENDED
+        # if bitmask[0] & 0x10:
+        #     self._connection.protocol = PROTOCOL.EXTENDED
         self._supports_serial = bitmask[13] & 0x04
         self._supports_status = bitmask[5] & 0x08
         self._supports_subscriptions = bitmask[0] & 0x40

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -374,6 +374,9 @@ class Panel:
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
         # Section 13.2 of the protocol spec.
         bitmask = data[23:].ljust(33, b'\0')
+        # As detailed in https://github.com/mag1024/bosch-alarm-mode2/pull/20
+        # there is a bug with the extended protocol that leads to long events
+        # being truncated in some cases, so we have disabled it for the moment.
         # if bitmask[0] & 0x10:
         #     self._connection.protocol = PROTOCOL.EXTENDED
         self._supports_serial = bitmask[13] & 0x04

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -377,6 +377,8 @@ class Panel:
         # As detailed in https://github.com/mag1024/bosch-alarm-mode2/pull/20
         # there is a bug with the extended protocol that leads to long events
         # being truncated in some cases, so we have disabled it for the moment.
+        # This should eventually be solved in a future firmware update, and we
+        # at that point we can revisit this.
         # if bitmask[0] & 0x10:
         #     self._connection.protocol = PROTOCOL.EXTENDED
         self._supports_serial = bitmask[13] & 0x04

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -378,7 +378,7 @@ class Panel:
         # there is a bug with the extended protocol that leads to long events
         # being truncated in some cases, so we have disabled it for the moment.
         # This should eventually be solved in a future firmware update, and we
-        # at that point we can revisit this.
+        # at that point can revisit this.
         # if bitmask[0] & 0x10:
         #     self._connection.protocol = PROTOCOL.EXTENDED
         self._supports_serial = bitmask[13] & 0x04


### PR DESCRIPTION
As noted in https://github.com/mag1024/bosch-alarm-mode2/pull/20, there is currently a bug in the firmwares that support this protocol, and I don't think it provides all that much value currently as we don't pull back lots of history anymore. In the future we may be able to enable this again once a fixed firmware is released.