### PR TITLE
Fix output mapping for solution panels

### DIFF
--- a/bosch_alarm_mode2/const.py
+++ b/bosch_alarm_mode2/const.py
@@ -177,6 +177,7 @@ class CMD:
     SET_SUBSCRIPTION = 0x5F
     # Diagnostic group
     PRODUCT_SERIAL = 0x4A
+    READ_CONFIG_IMAGE = 0xA0
 
 class PROTOCOL:
     BASIC = 0x01

--- a/bosch_alarm_mode2/const.py
+++ b/bosch_alarm_mode2/const.py
@@ -177,7 +177,6 @@ class CMD:
     SET_SUBSCRIPTION = 0x5F
     # Diagnostic group
     PRODUCT_SERIAL = 0x4A
-    READ_CONFIG_IMAGE = 0xA0
 
 class PROTOCOL:
     BASIC = 0x01

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -445,6 +445,7 @@ class Panel:
         return data_out
 
     async def _load_output_subscription_config(self):
+        # Construct a mapping from remote outputs to actual outputs on solution panels
         # Locations for various outputs in memory
         # https://csproducts.co.nz/download/20003000_manuals/2000-3000-Quick-Installer-Manual.pdf
         output_1_location = 436
@@ -452,7 +453,7 @@ class Panel:
         b308_output_1_location = 646
         b228_output_2_location = 748
 
-        # Each output takes 6 bytes in memory
+        # Each output takes 6 bytes in the config image
         output_data_size = 6
 
         # Subscription events received from the solution series start at output 2
@@ -468,8 +469,8 @@ class Panel:
         # Build a list of all valid event codes
         event_codes = list(range(remote_1_code, remote_3_code+1)) + list(range(remote_4_code, remote_22_code+1))
 
-        # Map each event code to its remote output number
-        event_codes = {k: v+1 for v, k in enumerate(event_codes)}
+        # Map each event code to its remote output number (starting at 1)
+        event_codes = {event_code: remote_output+1 for remote_output, event_code in enumerate(event_codes)}
 
         # Build a list of all config locations for the various outputs
         locations = list(range(output_1_location, output_codepad_location+1, output_data_size))

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -159,7 +159,7 @@ class Panel:
         self._output_text_supported_format = 0
         self._point_text_supported_format = 0
         self._alarm_summary_supported_format = 0
-        self._requires_subscription_indices = False
+        self._requires_output_mappings = False
         self._outputs_by_subscription = {}
         self._output_semaphore = asyncio.Semaphore(1)
 
@@ -377,7 +377,7 @@ class Panel:
             LOG.warning('busy flag: %d', data[13])
 
         # Solution panels have a concept of "Remote Outputs", and we need to construct a mapping for those panels
-        self._requires_subscription_indices = data[0] <= 0x21
+        self._requires_output_mappings = data[0] <= 0x21
 
         # Solution and AMAX panels use different arming types from B/G series panels.
         if data[0] <= 0x24:
@@ -444,7 +444,7 @@ class Panel:
                 i = i + length
         return data_out
 
-    async def _load_output_subscription_config(self):
+    async def _load_solution_output_mappings(self):
         # Construct a mapping from remote outputs to actual outputs on solution panels
         # Locations for various outputs in memory
         # https://csproducts.co.nz/download/20003000_manuals/2000-3000-Quick-Installer-Manual.pdf
@@ -505,8 +505,8 @@ class Panel:
             "OUTPUT", 1
         )
         self.outputs = {id: Output(name) for id, name in names.items()}
-        if self._requires_subscription_indices:
-            await self._load_output_subscription_config()
+        if self._requires_output_mappings:
+            await self._load_solution_output_mappings()
         else:
             self._outputs_by_subscription = self.outputs
 

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -594,9 +594,9 @@ class Panel:
         return 5
 
     def _output_status_consumer(self, data) -> int:
-        # Solution panels send us events with different output IDs.
-        # This means we can't actually rely on the data from the
-        # subscription event and instead need to poll for output status
+        # Solution panels send events with output ids that don't match those
+        # used by the rest of the commands. This means we can't actually rely 
+        # on the data from the subscription event and instead need to poll for output status
         asyncio.create_task(self._load_output_status())
         return 3
     

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -458,14 +458,17 @@ class Panel:
         # Subscription events received from the solution series start at output 2
         output_subscription_offset = 2
 
-        # Event code IDs get split between remote output 3 and 4
+        # Event codes get split between remote output 3 and 4
+        # These codes were taken directly from A-Link
         remote_1_code = 0x28
         remote_3_code = 0x2A
         remote_4_code = 0x62
         remote_22_code = 0x74
 
-        # Build a list of all valid event code IDs
+        # Build a list of all valid event codes
         event_codes = list(range(remote_1_code, remote_3_code+1)) + list(range(remote_4_code, remote_22_code+1))
+
+        # Map each event code to its remote output number
         event_codes = {k: v+1 for v, k in enumerate(event_codes)}
 
         # Build a list of all config locations for the various outputs
@@ -484,7 +487,7 @@ class Panel:
                 starting_offset = get_offset_from_location(prev_location)
                 data = await self._read_config(prev_location)
 
-            # Then retrieve the event code for a given location
+            # Then retrieve the event code at a given location
             current_offset = get_offset_from_location(location)
             current_event_code = data[current_offset - starting_offset]
 

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -377,9 +377,6 @@ class Panel:
             if not self._installer_code:
                 raise ValueError(
                     "The installer code is required for Solution / AMAX panels")
-            # Solution panels don't require an automation code
-            if data[0] <= 0x21:
-                self._automation_code = None
         else:
             self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
@@ -597,6 +594,9 @@ class Panel:
         return 5
 
     def _output_status_consumer(self, data) -> int:
+        # Solution panels send us events with different output IDs.
+        # This means we can't actually rely on the data from the
+        # subscription event and instead need to poll for output status
         asyncio.create_task(self._load_output_status())
         return 3
     

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -24,8 +24,9 @@ def _supported_format(value, masks):
 
 def get_offset_from_location(location):
     # Panel "locations" actually refer to a nibble in memory, not a byte.
-    # There also seems to be a offset of 4 bytes, possibly some sort of header?
+    # Also need to skip past the 4 byte header at the start of the config image.
     return int((location / 2) + 4)
+
 class PanelEntity:
     def __init__(self, name, status):
         self.name = name

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -22,11 +22,6 @@ def _supported_format(value, masks):
             return format
     return 0
 
-def get_offset_from_location(location):
-    # Panel "locations" actually refer to a nibble in memory, not a byte.
-    # Also need to skip past the 4 byte header at the start of the config image.
-    return int((location / 2) + 4)
-
 class PanelEntity:
     def __init__(self, name, status):
         self.name = name
@@ -160,8 +155,6 @@ class Panel:
         self._output_text_supported_format = 0
         self._point_text_supported_format = 0
         self._alarm_summary_supported_format = 0
-        self._requires_output_mappings = False
-        self._outputs_by_subscription = {}
         self._output_semaphore = asyncio.Semaphore(1)
 
         if self._installer_code:
@@ -377,9 +370,6 @@ class Panel:
         if data[13]:
             LOG.warning('busy flag: %d', data[13])
 
-        # Solution panels have a concept of "Remote Outputs", and we need to construct a mapping for those panels
-        self._requires_output_mappings = data[0] <= 0x21
-
         # Solution and AMAX panels use different arming types from B/G series panels.
         if data[0] <= 0x24:
             self._partial_arming_id = AREA_ARMING_STAY1
@@ -387,6 +377,9 @@ class Panel:
             if not self._installer_code:
                 raise ValueError(
                     "The installer code is required for Solution / AMAX panels")
+            # Solution panels don't require an automation code
+            if data[0] <= 0x21:
+                self._automation_code = None
         else:
             self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
@@ -426,79 +419,6 @@ class Panel:
             revision = int.from_bytes(data[1:2], 'big')
             self.firmware_version = 'v%d.%d' % (version, revision)
 
-    async def _read_config(self, location):
-        data = await self._connection.send_command(CMD.READ_CONFIG_IMAGE, bytearray(get_offset_from_location(location).to_bytes(2, 'big')))
-        # skip over offset
-        data = data[2:]
-        # Config is run-length encoded, so we need to decode it
-        data_out = bytearray()
-        i = 0
-        while i < len(data):
-            length = data[i]
-            i = i + 1
-            if length >= 128:
-                length = length - 125
-                data_out.extend([data[i]] * length)
-                i = i + 1
-            else:
-                data_out.extend(data[i:i+length+1])
-                i = i + length
-        return data_out
-
-    async def _load_solution_output_mappings(self):
-        # Construct a mapping from remote outputs to actual outputs on solution panels
-        # Locations for various outputs in memory
-        # https://csproducts.co.nz/download/20003000_manuals/2000-3000-Quick-Installer-Manual.pdf
-        output_1_location = 436
-        output_codepad_location = 460
-        b308_output_1_location = 646
-        b228_output_2_location = 748
-
-        # Each output takes 6 bytes in the config image
-        output_data_size = 6
-
-        # Subscription events received from the solution series start at output 2
-        output_subscription_offset = 2
-
-        # Event codes get split between remote output 3 and 4
-        # These codes were taken directly from A-Link
-        remote_1_code = 0x28
-        remote_3_code = 0x2A
-        remote_4_code = 0x62
-        remote_22_code = 0x74
-
-        # Build a list of all valid event codes
-        event_codes = list(range(remote_1_code, remote_3_code+1)) + list(range(remote_4_code, remote_22_code+1))
-
-        # Map each event code to its remote output number (starting at 1)
-        event_codes = {event_code: remote_output+1 for remote_output, event_code in enumerate(event_codes)}
-
-        # Build a list of all config locations for the various outputs
-        locations = list(range(output_1_location, output_codepad_location+1, output_data_size))
-        locations += list(range(b308_output_1_location, b228_output_2_location+1, output_data_size))
-
-        # Read config data from the panel
-        prev_location = 0
-        starting_offset = 0
-        data = bytearray()
-        for i, location in enumerate(locations):
-            # There is a limit to how many items we can read at one time
-            # So, batch up queries in sets of 30 locations at a time
-            if location - prev_location > 30:
-                prev_location = location
-                starting_offset = get_offset_from_location(prev_location)
-                data = await self._read_config(prev_location)
-
-            # Then retrieve the event code at a given location
-            current_offset = get_offset_from_location(location)
-            current_event_code = data[current_offset - starting_offset]
-
-            # And map it to an output number, and store a mapping that we can refer to later
-            if current_event_code in event_codes:
-                remote_output_number = event_codes[current_event_code]
-                if remote_output_number in self.outputs:
-                    self._outputs_by_subscription[i + output_subscription_offset] = self.outputs[remote_output_number]
-
     async def _load_outputs(self):
         names = await self._load_names(
             CMD.OUTPUT_TEXT, CMD.REQUEST_CONFIGURED_OUTPUTS, 
@@ -506,10 +426,6 @@ class Panel:
             "OUTPUT", 1
         )
         self.outputs = {id: Output(name) for id, name in names.items()}
-        if self._requires_output_mappings:
-            await self._load_solution_output_mappings()
-        else:
-            self._outputs_by_subscription = self.outputs
 
     async def _load_areas(self):
         names = await self._load_names(
@@ -681,10 +597,7 @@ class Panel:
         return 5
 
     def _output_status_consumer(self, data) -> int:
-        output_id = BE_INT.int16(data)
-        if output_id in self._outputs_by_subscription:
-            output_status = self._outputs_by_subscription[output_id].status = int(data[2] != 0)
-            LOG.debug("Output updated %d: %s" % (output_id, OUTPUT_STATUS.TEXT[output_status]))
+        asyncio.create_task(self._load_output_status())
         return 3
     
     def _point_status_consumer(self, data) -> int:


### PR DESCRIPTION
Solution panels are very weird with how outputs work. 

There is a concept of "Remote outputs", which govern which outputs can be controlled by Mode2. 
This gives the installer control over which outputs map to a given remote output that is controlled by Mode2. 

The problem with this, is that subscription events give us information based on the raw output ID, not the remote one.

To solve this, I have parsed the raw configuration of the panel, and used that to build a mapping from raw output ID to remote output ID. I then use this mapping when we receive a subscription event to make sure the event IDs are aligned.

Do note that this requires we merge https://github.com/mag1024/bosch-alarm-mode2/pull/25 first, as these configuration commands are only available to installers, and https://github.com/mag1024/bosch-alarm-mode2/pull/25 changes the user scope from user to installer.

Also note that I have  undone https://github.com/mag1024/bosch-alarm-mode2/pull/21 here as well, as when testing this I found that outputs without a name are coming through as empty from my solution 3000, which means empty but configured outputs were being ignored. We will need to work out why `REQUEST_CONFIGURED_OUTPUTS` does not work on your panel? Were you able to get your hands on a configuration key so you can validate your configuration, and check if those empty output configurations are in fact valid?