### PR TITLE
Revert solution auth changes

### DIFF
--- a/bin/alarm.py
+++ b/bin/alarm.py
@@ -24,7 +24,7 @@ asyncio.set_event_loop(loop)
 panel = Panel(
     host=args.host, port=args.port, 
     automation_code=args.automation_code, 
-    installer_or_user_code=args.installer_code)
+    installer_or_user_code=args.installer_or_user_code)
 try:
     loop.run_until_complete(panel.connect())
     panel.print()

--- a/bin/alarm.py
+++ b/bin/alarm.py
@@ -10,7 +10,7 @@ from bosch_alarm_mode2 import Panel
 cli_parser = argparse.ArgumentParser()
 cli_parser.add_argument('--host', help="panel hostname")
 cli_parser.add_argument('--port', type=int, help="panel port")
-cli_parser.add_argument('-U', '--installer-code', help="Installer code")
+cli_parser.add_argument('-U', '--installer-or-user-code', help="Installer code")
 cli_parser.add_argument('-A', '--automation-code', help="Automation passcode")
 
 args = cli_parser.parse_args()
@@ -21,7 +21,10 @@ logging.basicConfig(stream = sys.stdout,
 
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
-panel = Panel(host=args.host, port=args.port, automation_code=args.automation_code, installer_or_user_code=args.installer_code)
+panel = Panel(
+    host=args.host, port=args.port, 
+    automation_code=args.automation_code, 
+    installer_or_user_code=args.installer_code)
 try:
     loop.run_until_complete(panel.connect())
     panel.print()

--- a/bin/alarm.py
+++ b/bin/alarm.py
@@ -21,7 +21,7 @@ logging.basicConfig(stream = sys.stdout,
 
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
-panel = Panel(host=args.host, port=args.port, automation_code=args.automation_code, installer_code=args.installer_code)
+panel = Panel(host=args.host, port=args.port, automation_code=args.automation_code, installer_or_user_code=args.installer_code)
 try:
     loop.run_until_complete(panel.connect())
     panel.print()

--- a/bin/alarm.py
+++ b/bin/alarm.py
@@ -10,7 +10,7 @@ from bosch_alarm_mode2 import Panel
 cli_parser = argparse.ArgumentParser()
 cli_parser.add_argument('--host', help="panel hostname")
 cli_parser.add_argument('--port', type=int, help="panel port")
-cli_parser.add_argument('-U', '--installer-or-user-code', help="Installer code")
+cli_parser.add_argument('-U', '--installer-or-user-code', help="Installer or User code")
 cli_parser.add_argument('-A', '--automation-code', help="Automation passcode")
 
 args = cli_parser.parse_args()

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -123,11 +123,11 @@ class Output(PanelEntity):
 class Panel:
     """ Connection to a Bosch Alarm Panel using the "Mode 2" API. """
 
-    def __init__(self, host, port, automation_code, installer_code):
+    def __init__(self, host, port, automation_code, installer_or_user_code):
         LOG.debug("Panel created")
         self._host = host
         self._port = port
-        self._installer_or_user_code = installer_code
+        self._installer_or_user_code = installer_or_user_code
         self._automation_code = automation_code
 
         self.connection_status_observer = Observable()

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -360,6 +360,8 @@ class Panel:
             if not self._installer_or_user_code:
                 raise ValueError(
                     "The user code is required for Solution panels")
+            # Solution panels don't require an automation code
+            self._automation_code = None
         elif "AMAX" in self.model:
             if not self._installer_or_user_code:
                 raise ValueError(
@@ -367,9 +369,12 @@ class Panel:
             if not self._automation_code:
                 raise ValueError(
                     "The Automation code is required for AMAX panels")
-        elif not self._automation_code:
-            raise ValueError(
-                "The Automation code is required for B/G panels")
+        else:
+            if not self._automation_code:
+                raise ValueError(
+                    "The Automation code is required for B/G panels")
+            # B/G series panels only require the automation code
+            self._installer_or_user_code = None
         if self._automation_code:
             await self._authenticate_automation_user()
         if self._installer_or_user_code:
@@ -395,14 +400,9 @@ class Panel:
             # However, subscriptions status messages include information about all outputs. 
             # Outputs with the "remote output" type start at index 6.
             self._output_subscription_start_index = 6
-            # Solution panels don't require an automation code
-            if data[0] <= 0x21:
-                self._automation_code = None
         else:
             self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
-            # B/G series panels only require the automation code
-            self._installer_or_user_code = None
         # Section 13.2 of the protocol spec.
         bitmask = data[23:].ljust(33, b'\0')
         # As detailed in https://github.com/mag1024/bosch-alarm-mode2/pull/20

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -127,7 +127,7 @@ class Panel:
         LOG.debug("Panel created")
         self._host = host
         self._port = port
-        self._installer_code = installer_code
+        self._installer_or_user_code = installer_code
         self._automation_code = automation_code
 
         self.connection_status_observer = Observable()
@@ -157,13 +157,13 @@ class Panel:
         self._output_subscription_start_index = 0
         self._output_semaphore = asyncio.Semaphore(1)
 
-        if self._installer_code:
-            if not self._installer_code.isnumeric():
+        if self._installer_or_user_code:
+            if not self._installer_or_user_code.isnumeric():
                 raise ValueError(
-                    "The installer code should only contain numerical digits.")
-            if len(self._installer_code) > 8:
+                    "The installer / user code should only contain numerical digits.")
+            if len(self._installer_or_user_code) > 8:
                 raise ValueError(
-                    "The installer code has a maximum length of 8 digits.")
+                    "The installer / user code has a maximum length of 8 digits.")
 
     LOAD_BASIC_INFO = 1 << 0
     LOAD_ENTITIES = 1 << 1
@@ -249,7 +249,7 @@ class Panel:
     async def _connect(self, load_selector):
         LOG.info('Connecting to %s:%d...', self._host, self._port)
         def connection_factory(): return Connection(
-                self._installer_code, self._on_status_update, self._on_disconnect)
+                self._installer_or_user_code, self._on_status_update, self._on_disconnect)
         _, connection = await asyncio.wait_for(
                 asyncio.get_running_loop().create_connection(
                     connection_factory,
@@ -334,7 +334,7 @@ class Panel:
 
     async def _authenticate_remote_user(self):
         try:
-            creds = int(str(self._installer_code).ljust(8, "F"), 16)
+            creds = int(str(self._installer_or_user_code).ljust(8, "F"), 16)
             creds = creds.to_bytes(4, "big")
             await self._connection.send_command(CMD.LOGIN_REMOTE_USER, creds)
         except Exception:
@@ -356,7 +356,7 @@ class Panel:
     async def _authenticate(self):
         if self._automation_code:
             await self._authenticate_automation_user()
-        if self._installer_code:
+        if self._installer_or_user_code:
             await self._authenticate_remote_user()
 
     async def _basicinfo(self):
@@ -379,17 +379,19 @@ class Panel:
             # However, subscriptions status messages include information about all outputs. 
             # Outputs with the "remote output" type start at index 6.
             self._output_subscription_start_index = 6
-            if not self._installer_code:
-                raise ValueError(
-                    "The installer code is required for Solution / AMAX panels")
             # Solution panels don't require an automation code
             if data[0] <= 0x21:
                 self._automation_code = None
+                raise ValueError(
+                    "The user code is required for Solution panels")
+            elif not self._installer_or_user_code:
+                raise ValueError(
+                    "The installer code is required for AMAX panels")
         else:
             self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
             self._all_arming_id = AREA_ARMING_MASTER_DELAY
             # B/G series panels only require the automation code, AMAX and Solution panels require both
-            self._installer_code = None
+            self._installer_or_user_code = None
         # Section 13.2 of the protocol spec.
         bitmask = data[23:].ljust(33, b'\0')
         # As detailed in https://github.com/mag1024/bosch-alarm-mode2/pull/20

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -382,6 +382,9 @@ class Panel:
             if not self._installer_code:
                 raise ValueError(
                     "The installer code is required for Solution / AMAX panels")
+            # Solution panels don't require an automation code
+            if data[0] <= 0x21:
+                self._automation_code = None
         else:
             self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
             self._all_arming_id = AREA_ARMING_MASTER_DELAY

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -356,9 +356,10 @@ class Panel:
         raise PermissionError("Authentication failed: " + error)
 
     async def _authenticate(self):
-        if "Solution" in self.model and not self._installer_or_user_code:
-            raise ValueError(
-                "The user code is required for Solution panels")
+        if "Solution" in self.model:
+            if not self._installer_or_user_code:
+                raise ValueError(
+                    "The user code is required for Solution panels")
         elif "AMAX" in self.model:
             if not self._installer_or_user_code:
                 raise ValueError(

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -157,14 +157,6 @@ class Panel:
         self._output_subscription_start_index = 0
         self._output_semaphore = asyncio.Semaphore(1)
 
-        if self._installer_or_user_code:
-            if not self._installer_or_user_code.isnumeric():
-                raise ValueError(
-                    "The installer / user code should only contain numerical digits.")
-            if len(self._installer_or_user_code) > 8:
-                raise ValueError(
-                    "The installer / user code has a maximum length of 8 digits.")
-
     LOAD_BASIC_INFO = 1 << 0
     LOAD_ENTITIES = 1 << 1
     LOAD_STATUS = 1 << 2
@@ -360,6 +352,12 @@ class Panel:
             if not self._installer_or_user_code:
                 raise ValueError(
                     "The user code is required for Solution panels")
+            if not self._installer_or_user_code.isnumeric():
+                raise ValueError(
+                    "The user code should only contain numerical digits.")
+            if len(self._installer_or_user_code) > 8:
+                raise ValueError(
+                    "The user code has a maximum length of 8 digits.")
             # Solution panels don't require an automation code
             self._automation_code = None
         elif "AMAX" in self.model:
@@ -369,12 +367,19 @@ class Panel:
             if not self._automation_code:
                 raise ValueError(
                     "The Automation code is required for AMAX panels")
+            if not self._installer_or_user_code.isnumeric():
+                raise ValueError(
+                    "The installer code should only contain numerical digits.")
+            if len(self._installer_or_user_code) > 8:
+                raise ValueError(
+                    "The installer code has a maximum length of 8 digits.")
         else:
             if not self._automation_code:
                 raise ValueError(
                     "The Automation code is required for B/G panels")
             # B/G series panels only require the automation code
             self._installer_or_user_code = None
+            
         if self._automation_code:
             await self._authenticate_automation_user()
         if self._installer_or_user_code:


### PR DESCRIPTION
With recent changes to https://github.com/mag1024/bosch-alarm-mode2/pull/27, we no longer need installer code permissions on the solution panels. This reverts that change, so that solution panels instead just use the standard user code, and no automation code.

This is good because it means users won't need to reconfigure their integrations when updating.