### PR TITLE
Bump connection timeout

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -246,7 +246,7 @@ class Panel:
                 asyncio.get_running_loop().create_connection(
                     connection_factory,
                     host=self._host, port=self._port, ssl=ssl_context),
-                timeout=100)
+                timeout=30)
         self._last_msg = datetime.now()
         self._connection = connection
         await self._basicinfo()

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -246,7 +246,7 @@ class Panel:
                 asyncio.get_running_loop().create_connection(
                     connection_factory,
                     host=self._host, port=self._port, ssl=ssl_context),
-                timeout=10)
+                timeout=100)
         self._last_msg = datetime.now()
         self._connection = connection
         await self._basicinfo()


### PR DESCRIPTION
Resolves https://github.com/mag1024/bosch-alarm-homeassistant/issues/19

Seems some panels have a slow initial connection, so we need to bump the timeout before assuming a panel is not responding. 