### PR TITLE
Fix issues with older AMAX panels

### DIFF
--- a/bosch_alarm_mode2/const.py
+++ b/bosch_alarm_mode2/const.py
@@ -202,3 +202,7 @@ class CMD:
 class PROTOCOL:
     BASIC = 0x01
     EXTENDED = 0x04
+
+class USER_TYPE:
+    INSTALLER_APP = 0x00
+    AUTOMATION = 0x01

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -56,7 +56,7 @@ class History:
         count = event_data[0]
         start = BE_INT.int32(event_data, 1)
         # AMAX panels use some bytes of the event id as flags
-        # Mask away these bytes.
+        # Apply a mask to only keep the actual event id
         if self._amax:
             start = start & 0x001FF
         start = start + 1

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -52,7 +52,7 @@ class History:
 
     def parse_polled_events(self, event_data):
         count = event_data[0]
-        start = self._parser._parse_event_id(event_data)
+        start = self._parser.parse_start_event_id(event_data) + 1
         event_data = event_data[5:]
         # Panels can have large numbers of history events, which take a very
         # long time load. Limit to EVENT_LOOKBACK_COUNT most recent events.
@@ -120,8 +120,8 @@ class HistoryParser:
     def parse_polled_event(self, id, event_data):
         return HistoryEvent(id, *self._parse_event(self._parse_event_params(event_data)))
 
-    def _parse_event_id(self, event_data):
-        return BE_INT.int32(event_data, 1)  + 1
+    def parse_start_event_id(self, event_data):
+        return BE_INT.int32(event_data, 1)
 
     @abc.abstractmethod
     def _parse_subscription_event_timestamp(self, timestamp) -> datetime:
@@ -184,10 +184,10 @@ class AmaxHistoryParser(HistoryParser):
     def _parse_subscription_event_timestamp(self, timestamp) -> datetime:
         return _parse_sol_amax_timestamp(timestamp)
 
-    def _parse_event_id(self, event_data):
+    def parse_start_event_id(self, event_data):
         # AMAX panels use some bytes of the event id as flags
         # Apply a mask to only keep the actual event id
-        return (BE_INT.int32(event_data, 1) & 0x001FF)  + 1
+        return (BE_INT.int32(event_data, 1) & 0x001FF)
 
     def _parse_event(self, event: HistoryEventParams):
         # Amax requires different strings depending on param1 sometimes

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -55,7 +55,8 @@ class History:
     def parse_polled_events(self, event_data):
         count = event_data[0]
         start = BE_INT.int32(event_data, 1)
-        # AMAX panels put extra data into the event ID that we need to strip away
+        # AMAX panels use some bytes of the event id as flags
+        # Mask away these bytes.
         if self._amax:
             start = start & 0x001FF
         start = start + 1

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -385,8 +385,7 @@ class Panel:
             if len(self._installer_or_user_code) > 8:
                 raise ValueError(
                     "The installer code has a maximum length of 8 digits.")
-            # AMAX panels require setting the user type to installer app
-            # Even though we authenticate with the automation code.
+            # AMAX panels require a user type of installer app, not automation
             user_type = USER_TYPE.INSTALLER_APP
         else:
             if not self._automation_code:

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -152,6 +152,7 @@ class Panel:
         self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
         self._all_arming_id = AREA_ARMING_MASTER_DELAY
         self._supports_serial = False
+        self._supports_permission_check = False
         self._set_subscription_supported_format = 0
         self._area_text_supported_format = 0
         self._output_text_supported_format = 0
@@ -338,13 +339,14 @@ class Panel:
             await self._connection.send_command(CMD.LOGIN_REMOTE_USER, creds)
         except Exception:
             raise PermissionError("Authentication failed, please check your passcode.")
-        permissions = await self._connection.send_command(
-            CMD.REQUEST_PERMISSION_FOR_PANEL_ACTION, bytearray([AUTHORITY_TYPE.GET_HISTORY]))
-        if not permissions[0]:
-            raise PermissionError("'Master code functions' authority required")
+        if self._supports_permission_check:
+            permissions = await self._connection.send_command(
+                CMD.REQUEST_PERMISSION_FOR_PANEL_ACTION, bytearray([AUTHORITY_TYPE.GET_HISTORY]))
+            if not permissions[0]:
+                raise PermissionError("'Master code functions' authority required")
 
-    async def _authenticate_automation_user(self):
-        creds = bytearray(b'\x01')  # automation user
+    async def _authenticate_automation_user(self, user_type):
+        creds = bytearray([user_type])  # automation user
         creds.extend(map(ord, self._automation_code))
         creds.append(0x00) # null terminate
         result = await self._connection.send_command(CMD.AUTHENTICATE, creds)
@@ -357,6 +359,7 @@ class Panel:
         raise PermissionError("Authentication failed: " + error)
 
     async def _authenticate(self):
+        user_type = USER_TYPE.AUTOMATION
         if "Solution" in self.model:
             if not self._installer_or_user_code:
                 raise ValueError(
@@ -382,6 +385,9 @@ class Panel:
             if len(self._installer_or_user_code) > 8:
                 raise ValueError(
                     "The installer code has a maximum length of 8 digits.")
+            # AMAX panels require setting the user type to installer app
+            # Even though we authenticate with the automation code.
+            user_type = USER_TYPE.INSTALLER_APP
         else:
             if not self._automation_code:
                 raise ValueError(
@@ -390,7 +396,7 @@ class Panel:
             self._installer_or_user_code = None
             
         if self._automation_code:
-            await self._authenticate_automation_user()
+            await self._authenticate_automation_user(user_type)
         if self._installer_or_user_code:
             await self._authenticate_remote_user()
 
@@ -429,7 +435,7 @@ class Panel:
         self._point_text_supported_format = _supported_format(bitmask[11], [(0x20, 3), (0x80, 1)])
         self._alarm_summary_supported_format = _supported_format(bitmask[2], [(0x10, 2), (0x20, 1)])
         self._set_subscription_supported_format = max(_supported_format(bitmask[24],[(0x40, 2)]), _supported_format(bitmask[16], [(0x20, 1)]))
-
+        self._supports_permission_check = bitmask[2] & 0x80
         self._history.init_for_panel(data[0])
         self._history_cmd = (
                 CMD.REQUEST_RAW_HISTORY_EVENTS_EXT if bitmask[16] & 0x02 else


### PR DESCRIPTION
Seems authentication on the AMAX panels differs once again.

We need to set the user type to installer app, not automation when we authenticate with the automation code.

Also, history ids are worse on the older AMAX panels, and the mask needs to be `0x1FF`.
This does mean we need to mask that out only for AMAX panels, since some of the other panels do allow having more than 512 events.

Also, the AMAX panels don't support the user permission check command, so actually validate that command is available before using it. Not that it matters anyways - when you use the automation code like this, you get all permissions anyways.