### PR TITLE
Limit the amount of commands in flight at a given time depending on the panel type

### DIFF
--- a/bosch_alarm_mode2/connection.py
+++ b/bosch_alarm_mode2/connection.py
@@ -20,7 +20,7 @@ class Connection(asyncio.Protocol):
         self._buffer = bytearray()
         self._pending = deque()
         self._pending_last_empty = datetime.now()
-        self._command_semaphore = asyncio.Semaphore(1)
+        self.set_max_commands_in_flight(1)
 
     def set_max_commands_in_flight(self, command_count):
         self._command_semaphore = asyncio.Semaphore(command_count)

--- a/bosch_alarm_mode2/connection.py
+++ b/bosch_alarm_mode2/connection.py
@@ -38,7 +38,8 @@ class Connection(asyncio.Protocol):
         self._consume_buffer()
 
     async def send_command(self, code, data = bytearray()) -> bytearray:
-        # Some panels don't like receiving multiple commands at once, so we limit commands to only run one at a time
+        # Some panels don't like receiving multiple commands at once 
+        # so we limit the amount of commands that are in flight at a given time
         async with self._command_semaphore:
             request = bytearray([self.protocol])
             length_size = 2 if self.protocol == PROTOCOL.EXTENDED else 1

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -464,7 +464,7 @@ class Panel:
         self.model = PANEL_MODEL[data[0]]
         self.protocol_version = 'v%d.%d' % (data[5], data[6])
         # B and G series panels support multiple commands in flight, AMAX and Solution panels do not.
-        if self.model >= 0xA0:
+        if data[0] >= 0xA0:
             self._connection.set_max_commands_in_flight(100)
         if data[13]:
             LOG.warning('busy flag: %d', data[13])

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -446,6 +446,9 @@ class Panel:
             data = await self._connection.send_command(CMD.WHAT_ARE_YOU)
         self.model = PANEL_MODEL[data[0]]
         self.protocol_version = 'v%d.%d' % (data[5], data[6])
+        # B and G series panels support multiple commands in flight, AMAX and Solution panels do not.
+        if self.model >= 0xA0:
+            self._connection.set_max_commands_in_flight(100)
         if data[13]:
             LOG.warning('busy flag: %d', data[13])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bosch-alarm-mode2"
-version = "0.3.41"
+version = "0.3.42"
 description = ""
 authors = ["Michael Grigoriev <mag@luminal.org>"]
 


### PR DESCRIPTION
Some bosch panels such as the solution and amax panels get confused if there is more than one packet in flight at a time, so I've added a semaphore to stop this from happening 