### PR TITLE
Allow users without history access to authenticate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In practice, this library has only been tested with B8512G and the B5512 and the
 #### Authentication
 - For all panels, make sure that your Automation Passcode is set to a passcode that is at least 10 characters long.
 - For B and G series panels, set the "Automation Device" to "Mode 2", and use just your automation code for authentication.
-- For Solution panels, use your user code for authentication. The user needs to have the "master code functions" authority.
+- For Solution panels, use your user code for authentication. The user needs to have the "master code functions" authority if you wish to interact with history events.
 - For AMAX panels, use both your automation code and your user code for authentication. 
 
 Full documentation of the API can be requested from

--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -25,6 +25,7 @@ class History:
         self._events = []
         self._parser = None
         self._max_count = 0
+        self.has_errored = False
 
     @property
     def events(self):

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -170,7 +170,6 @@ class Panel:
         self._partial_arming_id = AREA_ARMING_PERIMETER_DELAY
         self._all_arming_id = AREA_ARMING_MASTER_DELAY
         self._supports_serial = False
-        self._supports_permission_check = False
         self._supports_door = False
         self._set_subscription_supported_format = 0
         self._area_text_supported_format = 0
@@ -490,7 +489,6 @@ class Panel:
         self._point_text_supported_format = _supported_format(bitmask[11], [(0x20, 3), (0x80, 1)])
         self._alarm_summary_supported_format = _supported_format(bitmask[2], [(0x10, 2), (0x20, 1)])
         self._set_subscription_supported_format = max(_supported_format(bitmask[24],[(0x40, 2)]), _supported_format(bitmask[16], [(0x20, 1)]))
-        self._supports_permission_check = bitmask[2] & 0x80
         self._history.init_for_panel(data[0])
         self._history_cmd = (
                 CMD.REQUEST_RAW_HISTORY_EVENTS_EXT if bitmask[16] & 0x02 else


### PR DESCRIPTION
Closes #40 

We previously did a permission check to handle the case where a user doesn't have permission to get history events, but we can just do a try catch instead to handle the cases where a user can't run that command

This fixes an issue where you can't actually authenticate with a panel right now if it is armed, as a panel that is armed revokes permissions for reading history.

This means that now the integration is usable even if you don't have master code authority over a panel, it just stops history from working in that scenario.