### PR TITLE
Fix AMAX history event id parsing

### DIFF
--- a/bosch_alarm_mode2/history.py
+++ b/bosch_alarm_mode2/history.py
@@ -226,6 +226,8 @@ class History:
         for i in range(start, start + count):
             try:
                 e = self._parser.parse_polled_event(i, event_data)
+                if self._events and e.date < self._events[-1].date:
+                    return None
                 LOG.debug(e)
                 self._events.append(e)
                 event_data = event_data[event_length:]


### PR DESCRIPTION
After playing with my AMAX panel, ive come to the conclusion that it stops recording log entries when all 256 entries are filled up, and in that scenario the event id just keeps rolling over and we read events forever. 

The event ids seem to start at 256 and end at 512.

To avoid this, i just stop reading events if we get an event id > 512.