### PR TITLE
Allow getting faults by ids so we can build nicer sensors in HA

### DIFF
--- a/bosch_alarm_mode2/const.py
+++ b/bosch_alarm_mode2/const.py
@@ -185,7 +185,7 @@ class ALARM_MEMORY_PRIORITIES:
     GAS_ALARM = 0x09
     FIRE_ALARM = 0x0A
 
-    PRIORITY = [0x07, 0x09, 0x0A]
+    PRIORITY_ALARMS = [0x07, 0x09, 0x0A]
     
     TEXT = {
         BURGLARY_TROUBLE: "Burglary Trouble",

--- a/bosch_alarm_mode2/const.py
+++ b/bosch_alarm_mode2/const.py
@@ -173,36 +173,62 @@ class DOOR_ACTION:
     SECURE = 0x04
     TERMINATE_SECURE = 0x05
 
+class ALARM_MEMORY_PRIORITIES:
+    BURGLARY_TROUBLE = 0x01
+    BURGLARY_SUPERVISORY = 0x02
+    GAS_TROUBLE = 0x03
+    GAS_SUPERVISORY = 0x04
+    FIRE_TROUBLE = 0x05
+    FIRE_SUPERVISORY = 0x06
+    BURGLARY_ALARM = 0x07
+    PERSONAL_EMERGENCY = 0x08
+    GAS_ALARM = 0x09
+    FIRE_ALARM = 0x0A
 
-ALARM_MEMORY_PRIORITY_ALARMS = [0x07, 0x09, 0x0A]
+    PRIORITY = [0x07, 0x09, 0x0A]
+    
+    TEXT = {
+        BURGLARY_TROUBLE: "Burglary Trouble",
+        BURGLARY_SUPERVISORY: "Burglary Supervisory",
+        GAS_TROUBLE: "Gas Trouble",
+        GAS_SUPERVISORY: "Gas Supervisory",
+        FIRE_TROUBLE: "Fire Trouble",
+        FIRE_SUPERVISORY: "Fire Supervisory",
+        BURGLARY_ALARM: "Burglary Alarm",
+        PERSONAL_EMERGENCY: "Personal Emergency",
+        GAS_ALARM: "Gas Alarm",
+        FIRE_ALARM: "Fire Alarm",
+    }
 
-ALARM_MEMORY_PRIORITIES = {
-    0x01: "Burglary Trouble",
-    0x02: "Burglary Supervisory",
-    0x03: "Gas Trouble",
-    0x04: "Gas Supervisory",
-    0x05: "Fire Trouble",
-    0x06: "Fire Supervisory",
-    0x07: "Burglary Alarm",
-    0x08: "Personal Emergency",
-    0x09: "Gas Alarm",
-    0x0A: "Fire Alarm",
-}
 
-ALARM_PANEL_FAULTS = {
-    (1 << 1): "Phone line failure",
-    (1 << 2): "Parameter CRC fail in PIF",
-    (1 << 3): "Battery low",
-    (1 << 4): "Battery missing",
-    (1 << 5): "AC fail",
-    (1 << 7): "Communication fail since RPS hang up",
-    (1 << 8): "SDI fail since RPS hang up",
-    (1 << 9): "User code tamper since RPS hang up",
-    (1 << 10): "Fail to call RPS since RPS hang up",
-    (1 << 13): "Point bus fail since RPS hang up",
-    (1 << 14): "Log overflow",
-    (1 << 15): "Log threshold",
-}
+class ALARM_PANEL_FAULTS:
+    PHONE_LINE_FAILURE = (1 << 1)
+    PARAMETER_CRC_FAIL_IN_PIF = (1 << 2)
+    BATTERY_LOW = (1 << 3)
+    BATTERY_MISING = (1 << 4)
+    AC_FAIL = (1 << 5)
+    COMMUNICATION_FAIL_SINCE_RPS_HANG_UP = (1 << 7)
+    SDI_FAIL_SINCE_RPS_HANG_UP = (1 << 8)
+    USER_CODE_TAMPER_SINCE_RPS_HANG_UP = (1 << 9)
+    FAIL_TO_CALL_RPS_SINCE_RPS_HANG_UP = (1 << 10)
+    POINT_BUS_FAIL_SINCE_RPS_HANG_UP = (1 << 13)
+    LOG_OVERFLOW = (1 << 14)
+    LOG_THRESHOLD = (1 << 15)
+
+    TEXT = {
+        PHONE_LINE_FAILURE: "Phone line failure",
+        PARAMETER_CRC_FAIL_IN_PIF: "Parameter CRC fail in PIF",
+        BATTERY_LOW: "Battery low",
+        BATTERY_MISING: "Battery missing",
+        AC_FAIL: "AC fail",
+        COMMUNICATION_FAIL_SINCE_RPS_HANG_UP: "Communication fail since RPS hang up",
+        SDI_FAIL_SINCE_RPS_HANG_UP: "SDI fail since RPS hang up",
+        USER_CODE_TAMPER_SINCE_RPS_HANG_UP: "User code tamper since RPS hang up",
+        FAIL_TO_CALL_RPS_SINCE_RPS_HANG_UP: "Fail to call RPS since RPS hang up",
+        POINT_BUS_FAIL_SINCE_RPS_HANG_UP: "Point bus fail since RPS hang up",
+        LOG_OVERFLOW: "Log overflow",
+        LOG_THRESHOLD: "Log threshold",
+    }
 
 
 class AUTHORITY_TYPE:

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -116,7 +116,7 @@ class Area(PanelEntity):
 
     def is_triggered(self) -> bool:
         return (self.is_armed() or self.is_pending()) and bool(
-            self._alarms.intersection(ALARM_MEMORY_PRIORITIES.PRIORITY)
+            self._alarms.intersection(ALARM_MEMORY_PRIORITIES.PRIORITY_ALARMS)
         )
 
     def reset(self) -> None:

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -8,7 +8,6 @@ from typing import Any, Generator
 
 from .const import (
     ALARM_MEMORY_PRIORITIES,
-    ALARM_MEMORY_PRIORITY_ALARMS,
     ALARM_PANEL_FAULTS,
     AREA_ARMING_STATUS,
     AREA_READY_STATUS,
@@ -79,7 +78,11 @@ class Area(PanelEntity):
 
     @property
     def alarms(self) -> list[str]:
-        return [ALARM_MEMORY_PRIORITIES[x] for x in self._alarms]
+        return [ALARM_MEMORY_PRIORITIES.TEXT[x] for x in self._alarms]
+
+    @property
+    def alarms_ids(self) -> set[int]:
+        return self._alarms
 
     def _set_ready(self, ready: int, faults: int) -> None:
         self._ready = ready
@@ -113,7 +116,7 @@ class Area(PanelEntity):
 
     def is_triggered(self) -> bool:
         return (self.is_armed() or self.is_pending()) and bool(
-            self._alarms.intersection(ALARM_MEMORY_PRIORITY_ALARMS)
+            self._alarms.intersection(ALARM_MEMORY_PRIORITIES.PRIORITY)
         )
 
     def reset(self) -> None:
@@ -591,7 +594,11 @@ class Panel:
 
     @property
     def panel_faults(self) -> list[str]:
-        return [fault for mask, fault in ALARM_PANEL_FAULTS.items() if self._faults_bitmap & mask]
+        return [fault for mask, fault in ALARM_PANEL_FAULTS.TEXT.items() if self._faults_bitmap & mask]
+
+    @property
+    def panel_faults_ids(self) -> list[int]:
+        return [mask for mask in ALARM_PANEL_FAULTS.TEXT if self._faults_bitmap & mask]
 
     async def _load_faults(self) -> None:
         if self._supports_status:
@@ -723,7 +730,7 @@ class Panel:
 
         format = bytearray([0x02] if self._alarm_summary_supported_format == 2 else [])
         data = await self._send_command(CMD.ALARM_MEMORY_SUMMARY, format)
-        for priority in ALARM_MEMORY_PRIORITIES.keys():
+        for priority in ALARM_MEMORY_PRIORITIES.TEXT.keys():
             i = (priority - 1) * 2
             count = BE_INT.int16(data, i)
             if count:

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -81,8 +81,8 @@ class Area(PanelEntity):
         return [ALARM_MEMORY_PRIORITIES.TEXT[x] for x in self._alarms]
 
     @property
-    def alarms_ids(self) -> set[int]:
-        return self._alarms
+    def alarms_ids(self) -> list[int]:
+        return list(self._alarms)
 
     def _set_ready(self, ready: int, faults: int) -> None:
         self._ready = ready


### PR DESCRIPTION
I was talking to one of the devs and it was pointed out that things like faults would be better as separate binary sensors instead of just a single sensor with text in it, as that would allow people to do automation for specific faults easier.