### PR TITLE
Update email address for requesting mode 2 API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ In practice, this library has only been tested with B8512G and the B5512 and the
 - For AMAX panels, use both your automation code and your user code for authentication. 
 
 Full documentation of the API can be requested from
-integrated.solutions@us.bosch.com.
+integrated.solutions@keenfinity-group.com.


### PR DESCRIPTION
With the move of Bosch security products to Keenfinity, the address for requesting the mode 2 documentation has changed.