### PR TITLE
Fix issues with command 0x23

### DIFF
--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -723,8 +723,11 @@ class Panel:
             area = BE_INT.int16(response_detail)
             point = BE_INT.int16(response_detail, 3)
             if point == 0xFFFF:
-                await self._get_alarms_for_priority(priority, area, point)
+                # If the 11th point is 0xFFFF, then we need to send a request for the 10th point
+                await self._get_alarms_for_priority(priority, last_area, last_point)
                 return
+            last_area = area
+            last_point = point
             if area in self.areas:
                 self.areas[area]._set_alarm(priority, True)
             else:

--- a/bosch_alarm_mode2/panel.py
+++ b/bosch_alarm_mode2/panel.py
@@ -723,7 +723,8 @@ class Panel:
             area = BE_INT.int16(response_detail)
             point = BE_INT.int16(response_detail, 3)
             if point == 0xFFFF:
-                # If the 11th point is 0xFFFF, then we need to send a request for the 10th point
+                # # 0xFFFF is sentinel that indicates that more points are available.
+                # Issues a follow-up starting at the last valid point. 
                 await self._get_alarms_for_priority(priority, last_area, last_point)
                 return
             last_area = area


### PR DESCRIPTION
It was raised by bosch that we had our handling of command 0x23 slightly wrong, and that in some cases this was causing SOL panels to lock up and not be able to reestablish connections.

When we encountered a point with id 0xFFFF, we were requesting point 0xFFFF, but we actually should have been requesting the previous point not the final 0xFFFF point.

> The initial command should be sent without the last item fields present (length is 2 bytes) and will return a list of up to 10 results. If more results are pending, the 11th point/user/keypad value will be set to 0xFFFF. To retrieve the remainder, a subsequent command should be sent including the optional area and point/keypad/user fields set to the area and point/keypad/user value of the 10th item returned previously.